### PR TITLE
Modified Dockerfile and recognize.py to work with Wave2vec 2.0

### DIFF
--- a/src/recognize.py
+++ b/src/recognize.py
@@ -22,6 +22,29 @@ parser.add_argument('--target_dict_path', type=str,
                     default='dict.ltr.txt',
                     help='path of target dict (dict.ltr.txt)')
 
+def base_architecture(args):
+    args.no_pretrained_weights = getattr(args, "no_pretrained_weights", False)
+    args.dropout_input = getattr(args, "dropout_input", 0)
+    args.final_dropout = getattr(args, "final_dropout", 0)
+    args.apply_mask = getattr(args, "apply_mask", False)
+    args.dropout = getattr(args, "dropout", 0)
+    args.attention_dropout = getattr(args, "attention_dropout", 0)
+    args.activation_dropout = getattr(args, "activation_dropout", 0)
+
+    args.mask_length = getattr(args, "mask_length", 10)
+    args.mask_prob = getattr(args, "mask_prob", 0.5)
+    args.mask_selection = getattr(args, "mask_selection", "static")
+    args.mask_other = getattr(args, "mask_other", 0)
+    args.no_mask_overlap = getattr(args, "no_mask_overlap", False)
+    args.mask_channel_length = getattr(args, "mask_channel_length", 10)
+    args.mask_channel_prob = getattr(args, "mask_channel_prob", 0.5)
+    args.mask_channel_selection = getattr(args, "mask_channel_selection", "static")
+    args.mask_channel_other = getattr(args, "mask_channel_other", 0)
+    args.no_mask_channel_overlap = getattr(args, "no_mask_channel_overlap", False)
+
+    args.freeze_finetune_updates = getattr(args, "freeze_finetune_updates", 0)
+    args.feature_grad_mult = getattr(args, "feature_grad_mult", 0)
+    args.layerdrop = getattr(args, "layerdrop", 0.0)
 
 class Wav2VecCtc(BaseFairseqModel):
     def __init__(self, w2v_encoder, args):

--- a/wav2letter.Dockerfile
+++ b/wav2letter.Dockerfile
@@ -9,6 +9,7 @@ ENV KENLM_ROOT_DIR=/root/kenlm
 ENV LD_LIBRARY_PATH=/opt/intel/compilers_and_libraries_2018.5.274/linux/mkl/lib/intel64:$LD_IBRARY_PATH
 WORKDIR /root/wav2letter/bindings/python
 
+#added editdistance package as pip install 
 RUN TMPDIR=/data/mydir/ pip install --upgrade pip && pip install --cache-dir=/data/vincents/ --build /data/mydir/ editdistance soundfile packaging && pip install -e .
 
 WORKDIR /root

--- a/wav2letter.Dockerfile
+++ b/wav2letter.Dockerfile
@@ -9,7 +9,7 @@ ENV KENLM_ROOT_DIR=/root/kenlm
 ENV LD_LIBRARY_PATH=/opt/intel/compilers_and_libraries_2018.5.274/linux/mkl/lib/intel64:$LD_IBRARY_PATH
 WORKDIR /root/wav2letter/bindings/python
 
-RUN pip install --upgrade pip && pip install soundfile packaging && pip install -e .
+RUN TMPDIR=/data/mydir/ pip install --upgrade pip && pip install --cache-dir=/data/vincents/ --build /data/mydir/ editdistance soundfile packaging && pip install -e .
 
 WORKDIR /root
 RUN git clone https://github.com/pytorch/fairseq.git
@@ -17,4 +17,5 @@ RUN mkdir data
 COPY src/recognize.py /root/fairseq/examples/wav2vec/recognize.py
 
 WORKDIR /root/fairseq
-RUN pip install --editable ./ && python examples/speech_recognition/infer.py --help && python examples/wav2vec/recognize.py --help
+RUN TMPDIR=/data/mydir/ pip install --cache-dir=/data/mydir/ --editable ./ && python examples/speech_recognition/infer.py --help && python examples/wav2vec/recognize.py --help
+


### PR DESCRIPTION
Changed the wav2vec.Dockerfile to make it work with the current wave2vec 2.0 and the updated fairseq repository. Added the base_architecture definition locally to recognize.py as it was no longer available in fairseq Wav2vec models (https://github.com/pytorch/fairseq/blob/master/fairseq/models/wav2vec/wav2vec2_asr.py). 